### PR TITLE
Fix file output path when converting spectrograms

### DIFF
--- a/conversion.py
+++ b/conversion.py
@@ -170,8 +170,8 @@ def handle_image(filename, args):
 
     outname = filename \
         + file_suffix("Output", fft=args.fft, iter=args.iter) \
-        + ".wav", sample_rate
-    save_audio_file(audio, outname)
+        + ".wav"
+    save_audio_file(audio, outname, sample_rate)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `save_audio_file` receives correct output path and sample rate

## Testing
- `python -m py_compile $(git ls-files '*.py')`